### PR TITLE
Avoid hardcoded API version and add appsecret_proof validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.0.0
+
+* Add Graph API version parameter. Avoid hardcoded `v2.8`.
+* Add appsecret_proof verification.
+
 # Version 1.2.1
 
 * Make it work for ghc-8.4. See [#3](https://github.com/psibi/fb/issues/3)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ myCreds =
   { appName = "Your_APP_Name"
   , appId = "your_app_id"
   , appSecret = "xxxxxxxxxxxxxxxxx"
-  , appSecretProofVerification = False
   }
 
 apiVersion :: ApiVersion

--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ myCreds =
   { appName = "Your_APP_Name"
   , appId = "your_app_id"
   , appSecret = "xxxxxxxxxxxxxxxxx"
+  , appSecretProofVerification = False
   }
+
+apiVersion :: ApiVersion
+apiVersion = "v2.8"
 
 main :: IO ()
 main = do
   mgr <- newManager tlsManagerSettings
   let redirectUrl = "https://www.yourdomain.com/"
   runResourceT $
-    runFacebookT myCreds mgr $
+    runFacebookT myCreds apiVersion mgr $
     do url1 <- getUserAccessTokenStep1 redirectUrl ["public_profile", "email"]
        liftIO $ print ("Paste the url in browser and get code: " <> url1)
        code <- liftIO $ getLine

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ myCreds =
   { appName = "Your_APP_Name"
   , appId = "your_app_id"
   , appSecret = "xxxxxxxxxxxxxxxxx"
+  , appSecretProof = False
   }
 
 apiVersion :: ApiVersion

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fb
-version: '1.2.1'
+version: '2.0.0'
 synopsis: Bindings to Facebook's API.
 description: ! 'This package exports bindings to Facebook''s APIs (see
 

--- a/src/Facebook.hs
+++ b/src/Facebook.hs
@@ -17,6 +17,7 @@ module Facebook
   , UserAccessToken
   , AppAccessToken
   , AccessTokenData
+  , ApiVersion
   , hasExpired
   , isValid
    -- ** App access token

--- a/src/Facebook.hs
+++ b/src/Facebook.hs
@@ -35,6 +35,8 @@ module Facebook
   , DebugToken(..)
    -- ** Signed requests
   , parseSignedRequest
+  , addAppSecretProof
+  , makeAppSecretProof
    -- * Facebook's Graph API
    -- ** User
   , User(..)

--- a/src/Facebook/Auth.hs
+++ b/src/Facebook/Auth.hs
@@ -22,8 +22,8 @@ module Facebook.Auth
 #if __GLASGOW_HASKELL__ <= 784
 import Control.Applicative
 #endif
-import Control.Monad (guard, liftM, mzero)
-import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad (guard, mzero)
+import Control.Monad.IO.Class
 import Control.Monad.Trans.Maybe (MaybeT(..))
 import Crypto.Classes (constTimeEq)
 import Crypto.Hash.CryptoAPI (SHA256)
@@ -32,8 +32,8 @@ import Data.Aeson ((.:))
 import Data.Aeson.Parser (json')
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Time (getCurrentTime, addUTCTime, UTCTime)
 import Data.Typeable (Typeable)
+import Data.Time (getCurrentTime, addUTCTime, UTCTime)
 import Data.String (IsString(..))
 
 import qualified UnliftIO.Exception as E
@@ -59,7 +59,7 @@ import Facebook.Monad
 -- credentials.
 -- Ref: https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow
 getAppAccessToken
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => FacebookT Auth m AppAccessToken
 getAppAccessToken =
   runResourceInFb $
@@ -89,7 +89,7 @@ getAppAccessToken =
 -- authenticate the user, authorize your app and then redirect
 -- the user back into the provider 'RedirectUrl'.
 getUserAccessTokenStep1
-  :: Monad m
+  :: (Monad m, MonadIO m)
   => RedirectUrl -> [Permission] -> FacebookT Auth m Text
 getUserAccessTokenStep1 redirectUrl perms = do
   creds <- getCreds
@@ -121,7 +121,7 @@ getUserAccessTokenStep1 redirectUrl perms = do
 -- to this function that will complete the user authentication
 -- flow and give you an @'UserAccessToken'@.
 getUserAccessTokenStep2
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => RedirectUrl -- ^ Should be exactly the same
      -- as in 'getUserAccessTokenStep1'.
   -> [Argument] -- ^ Query parameters.
@@ -298,7 +298,7 @@ isValid token = do
 -- can't assume this).  Note that expired access tokens can't be
 -- extended, only valid tokens.
 extendUserAccessToken
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => UserAccessToken
   -> FacebookT Auth m (Either FacebookException UserAccessToken)
 extendUserAccessToken token@(UserAccessToken uid data_ _) = do
@@ -337,7 +337,7 @@ extendUserAccessToken token@(UserAccessToken uid data_ _) = do
 -- verifies its authencity and integrity using the HMAC and
 -- decodes its JSON object.
 parseSignedRequest
-  :: (AE.FromJSON a, Monad m)
+  :: (AE.FromJSON a, Monad m, MonadIO m)
   => B8.ByteString -- ^ Encoded Facebook signed request
   -> FacebookT Auth m (Maybe a)
 parseSignedRequest signedRequest =

--- a/src/Facebook/Auth.hs
+++ b/src/Facebook/Auth.hs
@@ -63,7 +63,7 @@ getAppAccessToken
   => FacebookT Auth m AppAccessToken
 getAppAccessToken =
   runResourceInFb $
-  do Just creds <- getCreds
+  do creds <- getCreds
      req <-
        fbreq "/oauth/access_token" Nothing $
        tsq creds [("grant_type", "client_credentials")]
@@ -92,7 +92,7 @@ getUserAccessTokenStep1
   :: Monad m
   => RedirectUrl -> [Permission] -> FacebookT Auth m Text
 getUserAccessTokenStep1 redirectUrl perms = do
-  Just creds <- getCreds
+  creds <- getCreds
   apiVersion <- getApiVersion
   withTier $
     \tier ->
@@ -132,7 +132,7 @@ getUserAccessTokenStep2 redirectUrl query =
       runResourceInFb $
       -- Get the access token data through Facebook's OAuth.
       do now <- liftIO getCurrentTime
-         Just creds <- getCreds
+         creds <- getCreds
          req <-
            fbreq "/oauth/access_token" Nothing $
            tsq creds [code, ("redirect_uri", TE.encodeUtf8 redirectUrl)]
@@ -309,7 +309,7 @@ extendUserAccessToken token@(UserAccessToken uid data_ _) = do
   where
     tryToExtend =
       runResourceInFb $
-      do Just creds <- getCreds
+      do creds <- getCreds
          req <-
            fbreq "/oauth/access_token" Nothing $
            tsq
@@ -352,7 +352,7 @@ parseSignedRequest signedRequest =
      -- Verify signature
      SignedRequestAlgorithm algo <- fromJson payload
      guard (algo == "HMAC-SHA256")
-     Just creds <- lift getCreds
+     creds <- lift getCreds
      let hmacKey = credsToHmacKey creds
          expectedSignature = Cereal.encode $ hmac' hmacKey encodedUnparsedPayload
      guard (signature `constTimeEq` expectedSignature)

--- a/src/Facebook/Auth.hs
+++ b/src/Facebook/Auth.hs
@@ -93,6 +93,7 @@ getUserAccessTokenStep1
   => RedirectUrl -> [Permission] -> FacebookT Auth m Text
 getUserAccessTokenStep1 redirectUrl perms = do
   creds <- getCreds
+  apiVersion <- getApiVersion
   withTier $
     \tier ->
        let urlBase =

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -2,7 +2,6 @@
 {-#LANGUAGE FlexibleContexts#-}
 {-#LANGUAGE OverloadedStrings#-}
 {-#LANGUAGE CPP#-}
-{-# LANGUAGE GADTs#-}
 
 module Facebook.Base
     ( fbreq
@@ -20,7 +19,6 @@ import Control.Applicative
 import Control.Monad (mzero)
 import Control.Monad.IO.Class (MonadIO)
 import Data.ByteString.Char8 (ByteString)
-import qualified Data.Serialize as Cereal
 import Data.Text (Text)
 import Data.Typeable (Typeable)
 

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -57,7 +57,7 @@ fbreq :: Monad m
 fbreq path mtoken query = do
 
     apiVersion <- getApiVersion
-    creds      <- getMCreds
+    creds      <- getCreds
 
     let appSecretProofAdder = case creds of
           Just c@( Credentials _ _ _ True ) -> addAppSecretProof c
@@ -132,26 +132,6 @@ asBS :: (Monad m) =>
         H.Response (C.ConduitT () ByteString m ())
      -> FacebookT anyAuth m ByteString
 asBS response = lift $ C.runConduit $ H.responseBody response .| fmap B.concat CL.consume
-
-
--- | An exception that may be thrown by functions on this
--- package.  Includes any information provided by Facebook.
-data FacebookException =
-    -- | An exception coming from Facebook.
-    FacebookException { fbeType    :: Text
-                      , fbeMessage :: Text
-                      }
-    -- | An exception coming from the @fb@ package's code.
-  | FbLibraryException { fbeMessage :: Text }
-    deriving (Eq, Ord, Show, Read, Typeable)
-
-instance A.FromJSON FacebookException where
-    parseJSON (A.Object v) =
-        FacebookException <$> v A..: "type"
-                          <*> v A..: "message"
-    parseJSON _ = mzero
-
-instance E.Exception FacebookException where
 
 
 -- | Same as 'H.http', but tries to parse errors and throw

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -57,7 +57,7 @@ fbreq :: Monad m
 fbreq path mtoken query = do
 
     apiVersion <- getApiVersion
-    creds      <- getCreds
+    creds      <- getMCreds
 
     let appSecretProofAdder = case creds of
           Just c@( Credentials _ _ _ True ) -> addAppSecretProof c

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -16,11 +16,9 @@ module Facebook.Base
     ) where
 
 import Control.Applicative
-import Control.Monad (mzero)
 import Control.Monad.IO.Class (MonadIO)
 import Data.ByteString.Char8 (ByteString)
 import Data.Text (Text)
-import Data.Typeable (Typeable)
 
 import qualified UnliftIO.Exception as E
 import Control.Monad.Trans.Class (MonadTrans)

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -56,7 +56,7 @@ fbreq :: Monad m
       -> FacebookT anyAuth m H.Request
 fbreq path mtoken query = do
     apiVersion        <- getApiVersion
-    addAppSecretProof <- getAppSecretProofAdder
+    appSecretProofAdder <- getAppSecretProofAdder
 
     withTier $ \tier ->
       let host = case tier of
@@ -69,7 +69,7 @@ fbreq path mtoken query = do
              , H.redirectCount = 3
              , H.queryString   =
                  HT.renderSimpleQuery False
-                 $ addAppSecretProof mtoken $ maybe id tsq mtoken query
+                 $ appSecretProofAdder mtoken $ maybe id tsq mtoken query
 #if MIN_VERSION_http_client(0,5,0)
              , H.responseTimeout = H.responseTimeoutMicro 120000000 -- 2 minutes
 #else

--- a/src/Facebook/Base.hs
+++ b/src/Facebook/Base.hs
@@ -55,8 +55,14 @@ fbreq :: Monad m
       -> HT.SimpleQuery              -- ^ Parameters.
       -> FacebookT anyAuth m H.Request
 fbreq path mtoken query = do
-    apiVersion        <- getApiVersion
-    appSecretProofAdder <- getAppSecretProofAdder
+
+    apiVersion <- getApiVersion
+    creds      <- getCreds
+
+    let appSecretProofAdder = case creds of
+          Just c@( Credentials _ _ _ True ) -> addAppSecretProof c
+          _ -> const id 
+
 
     withTier $ \tier ->
       let host = case tier of

--- a/src/Facebook/Monad.hs
+++ b/src/Facebook/Monad.hs
@@ -182,7 +182,7 @@ beta_runNoAuthFacebookT apiVersion manager (F act) =
 
 -- | Get the user's credentials, fail if they are not available.
 getCreds
-  :: Monad m
+  :: (Monad m, MonadIO m)
   => FacebookT Auth m Credentials
 getCreds = do
    mCreds <- getMCreds

--- a/src/Facebook/Monad.hs
+++ b/src/Facebook/Monad.hs
@@ -107,7 +107,7 @@ data NoAuth
 
 -- | Internal data kept inside 'FacebookT'.
 data FbData = FbData
-  { fbdCreds :: Maybe Credentials -- ^ Can be 'undefined'!
+  { fbdCreds :: Maybe Credentials
   , fbdManager :: !H.Manager
   , fbdTier :: !FbTier
   , fbdApiVersion :: !ApiVersion

--- a/src/Facebook/Monad.hs
+++ b/src/Facebook/Monad.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Facebook.Monad
   ( FacebookT
@@ -18,10 +20,12 @@ module Facebook.Monad
   , runNoAuthFacebookT
   , beta_runFacebookT
   , beta_runNoAuthFacebookT
+  , getApiVersion
   , getCreds
   , getManager
   , getTier
   , withTier
+  , getAppSecretProofAdder
   , runResourceInFb
   , mapFacebookT
    -- * Re-export
@@ -31,6 +35,7 @@ module Facebook.Monad
 import Control.Applicative (Applicative, Alternative)
 import Control.Monad (MonadPlus, liftM)
 import Control.Monad.Base (MonadBase(..))
+import Control.Monad.Fail
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Logger (MonadLogger(..))
@@ -40,7 +45,14 @@ import Control.Monad.Trans.Reader (ReaderT(..), ask, mapReaderT)
 import Data.Typeable (Typeable)
 import qualified Control.Monad.Trans.Resource as R
 
+import Crypto.Hash.CryptoAPI (SHA256)
+import Crypto.HMAC (hmac', MacKey(..))
+import qualified Data.Serialize as Cereal
+import qualified Data.Text.Encoding as TE
+
+
 import qualified Network.HTTP.Conduit as H
+import qualified Network.HTTP.Types as HT
 
 import Facebook.Types
 
@@ -51,7 +63,7 @@ import Facebook.Types
 -- supplied any 'Credentials').
 newtype FacebookT auth m a = F
   { unF :: ReaderT FbData m a -- FbData -> m a
-  } deriving (Functor, Applicative, Alternative, Monad, MonadFix, MonadPlus, MonadIO, MonadTrans, R.MonadThrow)
+  } deriving (Functor, Applicative, Alternative, Monad, MonadFix, MonadFail, MonadPlus, MonadIO, MonadTrans, R.MonadThrow)
 
 deriving instance
          (R.MonadResource m, MonadBase IO m) =>
@@ -99,6 +111,10 @@ data FbData = FbData
   { fbdCreds :: Credentials -- ^ Can be 'undefined'!
   , fbdManager :: !H.Manager
   , fbdTier :: !FbTier
+  , fbdApiVersion :: !ApiVersion
+  , fbdAppSecretProofAdder :: forall anyKind. Maybe (AccessToken anyKind)
+                           -> HT.SimpleQuery
+                           -> HT.SimpleQuery
   } deriving (Typeable)
 
 -- | Which Facebook tier should be used (see
@@ -112,37 +128,79 @@ data FbTier
 -- your credentials.
 runFacebookT
   :: Credentials -- ^ Your app's credentials.
+  -> ApiVersion -- ^ Api version
   -> H.Manager -- ^ Connection manager (see 'H.withManager').
   -> FacebookT Auth m a
   -> m a
-runFacebookT creds manager (F act) =
-  runReaderT act (FbData creds manager Production)
+runFacebookT creds apiVersion manager (F act) =
+  runReaderT act (FbData creds manager Production apiVersion  $ addAppSecretProof creds )
+
+
+addAppSecretProof :: Credentials
+                  -> Maybe (AccessToken anykind)
+                  -> HT.SimpleQuery
+                  -> HT.SimpleQuery
+addAppSecretProof creds mtoken query = makeAppSecretProof creds mtoken <> query
+
+-- | Make an appsecret_proof in case the given credentials access token is a
+-- user access token.
+-- See: https://developers.facebook.com/docs/graph-api/securing-requests/#appsecret_proof
+makeAppSecretProof
+  :: Credentials         -- ^ App credentials
+  -> Maybe ( AccessToken anyKind ) -- ^
+  -> HT.SimpleQuery
+makeAppSecretProof creds (Just ( UserAccessToken _ accessToken _ ))
+  = [( TE.encodeUtf8 "appsecret_proof", proof)]
+
+  where
+    key :: MacKey ctx SHA256
+    key   = MacKey $ appSecretBS creds
+    proof = Cereal.encode $ hmac' key ( TE.encodeUtf8 accessToken )
+makeAppSecretProof  _ _ = []
+
 
 -- | Run a computation in the 'FacebookT' monad without
 -- credentials.
-runNoAuthFacebookT :: H.Manager -> FacebookT NoAuth m a -> m a
-runNoAuthFacebookT manager (F act) =
+runNoAuthFacebookT
+  :: ApiVersion -- ^ Api version
+  -> H.Manager -- ^ Connection manager (see 'H.withManager').
+  -> FacebookT NoAuth m a -> m a
+runNoAuthFacebookT apiVersion manager (F act) =
   let creds = error "runNoAuthFacebookT: never here, serious bug"
-  in runReaderT act (FbData creds manager Production)
+  in runReaderT act (FbData creds manager Production apiVersion $ const id)
+ 
 
 -- | Same as 'runFacebookT', but uses Facebook's beta tier (see
 -- <https://developers.facebook.com/support/beta-tier/>).
-beta_runFacebookT :: Credentials -> H.Manager -> FacebookT Auth m a -> m a
-beta_runFacebookT creds manager (F act) =
-  runReaderT act (FbData creds manager Beta)
+beta_runFacebookT :: Credentials -> ApiVersion -> H.Manager -> FacebookT Auth m a -> m a
+beta_runFacebookT creds apiVersion manager (F act) =
+  runReaderT act (FbData creds manager Beta apiVersion $ addAppSecretProof creds)
 
 -- | Same as 'runNoAuthFacebookT', but uses Facebook's beta tier
 -- (see <https://developers.facebook.com/support/beta-tier/>).
-beta_runNoAuthFacebookT :: H.Manager -> FacebookT NoAuth m a -> m a
-beta_runNoAuthFacebookT manager (F act) =
+beta_runNoAuthFacebookT :: ApiVersion -> H.Manager -> FacebookT NoAuth m a -> m a
+beta_runNoAuthFacebookT apiVersion manager (F act) =
   let creds = error "beta_runNoAuthFacebookT: never here, serious bug"
-  in runReaderT act (FbData creds manager Beta)
+  in runReaderT act (FbData creds manager Beta apiVersion $ const id)
 
 -- | Get the user's credentials.
 getCreds
   :: Monad m
   => FacebookT Auth m Credentials
 getCreds = fbdCreds `liftM` F ask
+
+-- | Get the Graph API version.
+getApiVersion
+  :: Monad m
+  => FacebookT anyAuth m ApiVersion
+getApiVersion = fbdApiVersion `liftM` F ask
+
+getAppSecretProofAdder
+  :: Monad m
+  => FacebookT anyAuth m ( Maybe (AccessToken anyKind)
+                        -> HT.SimpleQuery
+                        -> HT.SimpleQuery )
+getAppSecretProofAdder = fbdAppSecretProofAdder `liftM` F ask
 
 -- | Get the 'H.Manager'.
 getManager

--- a/src/Facebook/Monad.hs
+++ b/src/Facebook/Monad.hs
@@ -26,6 +26,8 @@ module Facebook.Monad
   , getTier
   , withTier
   , getAppSecretProofAdder
+  , addAppSecretProof
+  , makeAppSecretProof
   , runResourceInFb
   , mapFacebookT
    -- * Re-export

--- a/src/Facebook/Object/Action.hs
+++ b/src/Facebook/Object/Action.hs
@@ -38,7 +38,7 @@ createAction
   -> UserAccessToken -- ^ Required user access token.
   -> FacebookT Auth m Id
 createAction (Action action) query mapptoken usertoken = do
-  creds <- getCreds
+  Just creds <- getCreds
   let post
         :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
         => Text -> AccessToken anyKind -> FacebookT Auth m Id

--- a/src/Facebook/Object/Action.hs
+++ b/src/Facebook/Object/Action.hs
@@ -38,7 +38,7 @@ createAction
   -> UserAccessToken -- ^ Required user access token.
   -> FacebookT Auth m Id
 createAction (Action action) query mapptoken usertoken = do
-  Just creds <- getCreds
+  creds <- getCreds
   let post
         :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
         => Text -> AccessToken anyKind -> FacebookT Auth m Id

--- a/src/Facebook/Object/Action.hs
+++ b/src/Facebook/Object/Action.hs
@@ -8,6 +8,7 @@ module Facebook.Object.Action
   ) where
 
 import Control.Arrow (first)
+import Control.Monad.IO.Class
 import Data.Function (on)
 import Data.String (IsString(..))
 import Data.Text (Text)
@@ -27,7 +28,7 @@ import Facebook.Graph
 -- >              , "when"   #= now ]
 -- >              token
 createAction
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => Action -- ^ Action kind to be created.
   -> [Argument] -- ^ Arguments of the action.
   -> Maybe AppAccessToken

--- a/src/Facebook/Object/Page.hs
+++ b/src/Facebook/Object/Page.hs
@@ -72,7 +72,7 @@ getPage_
   -> [Argument] -- ^ Arguments to be passed to Facebook
   -> Maybe AppAccessToken -- ^ Optional user access token
   -> FacebookT anyAuth m Page
-getPage_ id_ = getObject $ ("/" <> idCode id_)
+getPage_ id_ = getObject $ "/" <> idCode id_
 
 -- | Search pages by keyword. The user access token is optional.
 searchPages

--- a/src/Facebook/RealTime.hs
+++ b/src/Facebook/RealTime.hs
@@ -126,7 +126,7 @@ getSubscriptionsPath
   :: Monad m
   => FacebookT Auth m Text
 getSubscriptionsPath = do
-  creds <- getCreds
+  Just creds <- getCreds
   return $ T.concat ["/", appId creds, "/subscriptions"]
 
 -- | Information returned by Facebook about a real-time update
@@ -170,7 +170,7 @@ verifyRealTimeUpdateNotifications
      -- ^ Request body with JSON-encoded notifications.
   -> FacebookT Auth m (Maybe L.ByteString)
 verifyRealTimeUpdateNotifications sig body = do
-  creds <- getCreds
+  Just creds <- getCreds
   let key :: Crypto.MacKey ctx SHA1
       key = Crypto.MacKey (appSecretBS creds)
       hash = Crypto.hmac key body

--- a/src/Facebook/RealTime.hs
+++ b/src/Facebook/RealTime.hs
@@ -126,7 +126,7 @@ getSubscriptionsPath
   :: Monad m
   => FacebookT Auth m Text
 getSubscriptionsPath = do
-  Just creds <- getCreds
+  creds <- getCreds
   return $ T.concat ["/", appId creds, "/subscriptions"]
 
 -- | Information returned by Facebook about a real-time update
@@ -170,7 +170,7 @@ verifyRealTimeUpdateNotifications
      -- ^ Request body with JSON-encoded notifications.
   -> FacebookT Auth m (Maybe L.ByteString)
 verifyRealTimeUpdateNotifications sig body = do
-  Just creds <- getCreds
+  creds <- getCreds
   let key :: Crypto.MacKey ctx SHA1
       key = Crypto.MacKey (appSecretBS creds)
       hash = Crypto.hmac key body

--- a/src/Facebook/RealTime.hs
+++ b/src/Facebook/RealTime.hs
@@ -17,6 +17,7 @@ module Facebook.RealTime
 
 import Control.Applicative ((<$>), (<*>))
 import Control.Monad (liftM, mzero, void)
+import Control.Monad.IO.Class
 import Crypto.Hash.CryptoAPI (SHA1)
 import Data.ByteString.Char8 (ByteString)
 import Data.Text (Text)
@@ -123,7 +124,7 @@ modifySubscription object fields callbackUrl verifyToken apptoken = do
 
 -- | (Internal)  Get the subscription's path.
 getSubscriptionsPath
-  :: Monad m
+  :: (Monad m, MonadIO m)
   => FacebookT Auth m Text
 getSubscriptionsPath = do
   creds <- getCreds
@@ -155,7 +156,7 @@ listSubscriptions apptoken = do
   src <- fetchAllNextPages pager
   lift $ C.runConduit $ src C..| CL.consume
 
--- | Verifies the input's authenticity (i.e. it comes from
+-- | Verifi(es the input's authenticity (i.e. it comes from, MonadIO m)
 -- Facebook) and integrity by calculating its HMAC-SHA1 (using
 -- your application secret as the key) and verifying that it
 -- matches the value from the HTTP request's @X-Hub-Signature@
@@ -163,7 +164,7 @@ listSubscriptions apptoken = do
 -- otherwise @Just data@ is returned where @data@ is the original
 -- data.
 verifyRealTimeUpdateNotifications
-  :: Monad m
+  :: (Monad m, MonadIO m)
   => ByteString
      -- ^ @X-Hub-Signature@ HTTP header's value.
   -> L.ByteString
@@ -186,7 +187,7 @@ verifyRealTimeUpdateNotifications sig body = do
 -- 'verifyRealTimeUpdateNotifications' if you need to distinguish
 -- between these two error conditions).
 getRealTimeUpdateNotifications
-  :: (Monad m, A.FromJSON a)
+  :: (Monad m, A.FromJSON a, MonadIO m)
   => ByteString
      -- ^ @X-Hub-Signature@ HTTP header's value.
   -> L.ByteString

--- a/src/Facebook/TestUsers.hs
+++ b/src/Facebook/TestUsers.hs
@@ -100,7 +100,7 @@ createTestUser
   -> AppAccessToken -- ^ Access token for your app.
   -> FacebookT Auth m TestUser
 createTestUser userInfo token = do
-  creds <- getCreds
+  Just creds <- getCreds
   let query = ("method", "post") : createTestUserQueryArgs userInfo
   getObject ("/" <> appId creds <> "/accounts/test-users") query (Just token)
 
@@ -110,14 +110,14 @@ getTestUsers
   => AppAccessToken -- ^ Access token for your app.
   -> FacebookT Auth m (Pager TestUser)
 getTestUsers token = do
-  creds <- getCreds
+  Just creds <- getCreds
   getObject ("/" <> appId creds <> "/accounts/test-users") [] (Just token)
 
 disassociateTestuser
   :: (R.MonadUnliftIO m, R.MonadThrow m, R.MonadResource m)
   => TestUser -> AppAccessToken -> FacebookT Auth m Bool
 disassociateTestuser testUser _token = do
-  creds <- getCreds
+  Just creds <- getCreds
   getObjectBool
     ("/" <> (appId creds) <> "/accounts/test-users")
     [("uid", encodeUtf8 $ idCode $ tuId testUser), ("method", "delete")]

--- a/src/Facebook/TestUsers.hs
+++ b/src/Facebook/TestUsers.hs
@@ -16,6 +16,7 @@ module Facebook.TestUsers
 
 import Control.Applicative ((<$>), (<*>))
 import Control.Monad (unless, mzero)
+import Control.Monad.IO.Class
 import Data.ByteString.Lazy (fromStrict)
 import Data.Default
 import Data.Text
@@ -94,7 +95,7 @@ createTestUserQueryArgs (CreateTestUser installed name locale) =
 -- | Create a new test user.
 -- Ref: https://developers.facebook.com/docs/graph-api/reference/v2.8/app/accounts/test-users#publish
 createTestUser
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => CreateTestUser -- ^ How the test user should be
      -- created.
   -> AppAccessToken -- ^ Access token for your app.
@@ -106,7 +107,7 @@ createTestUser userInfo token = do
 
 -- | Get a list of test users.
 getTestUsers
-  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m)
+  :: (R.MonadResource m, R.MonadUnliftIO m, R.MonadThrow m, MonadIO m)
   => AppAccessToken -- ^ Access token for your app.
   -> FacebookT Auth m (Pager TestUser)
 getTestUsers token = do
@@ -114,7 +115,7 @@ getTestUsers token = do
   getObject ("/" <> appId creds <> "/accounts/test-users") [] (Just token)
 
 disassociateTestuser
-  :: (R.MonadUnliftIO m, R.MonadThrow m, R.MonadResource m)
+  :: (R.MonadUnliftIO m, R.MonadThrow m, R.MonadResource m, MonadIO m)
   => TestUser -> AppAccessToken -> FacebookT Auth m Bool
 disassociateTestuser testUser _token = do
   creds <- getCreds

--- a/src/Facebook/TestUsers.hs
+++ b/src/Facebook/TestUsers.hs
@@ -100,7 +100,7 @@ createTestUser
   -> AppAccessToken -- ^ Access token for your app.
   -> FacebookT Auth m TestUser
 createTestUser userInfo token = do
-  Just creds <- getCreds
+  creds <- getCreds
   let query = ("method", "post") : createTestUserQueryArgs userInfo
   getObject ("/" <> appId creds <> "/accounts/test-users") query (Just token)
 
@@ -110,14 +110,14 @@ getTestUsers
   => AppAccessToken -- ^ Access token for your app.
   -> FacebookT Auth m (Pager TestUser)
 getTestUsers token = do
-  Just creds <- getCreds
+  creds <- getCreds
   getObject ("/" <> appId creds <> "/accounts/test-users") [] (Just token)
 
 disassociateTestuser
   :: (R.MonadUnliftIO m, R.MonadThrow m, R.MonadResource m)
   => TestUser -> AppAccessToken -> FacebookT Auth m Bool
 disassociateTestuser testUser _token = do
-  Just creds <- getCreds
+  creds <- getCreds
   getObjectBool
     ("/" <> (appId creds) <> "/accounts/test-users")
     [("uid", encodeUtf8 $ idCode $ tuId testUser), ("method", "delete")]

--- a/src/Facebook/Types.hs
+++ b/src/Facebook/Types.hs
@@ -58,6 +58,7 @@ data Credentials = Credentials
   { appName :: Text -- ^ Your application name (e.g. for Open Graph calls).
   , appId :: Text -- ^ Your application ID.
   , appSecret :: Text -- ^ Your application secret key.
+  , appSecretProof :: Bool -- ^ To enable app secret proof verification
   } deriving (Eq, Ord, Show, Read, Typeable)
 
 -- | 'appId' for 'ByteString'.

--- a/src/Facebook/Types.hs
+++ b/src/Facebook/Types.hs
@@ -7,6 +7,7 @@
 
 module Facebook.Types
   ( Credentials(..)
+  , ApiVersion
   , appIdBS
   , appSecretBS
   , AccessToken(..)
@@ -66,6 +67,11 @@ appIdBS = TE.encodeUtf8 . appId
 -- | 'appSecret' for 'ByteString'.
 appSecretBS :: Credentials -> ByteString
 appSecretBS = TE.encodeUtf8 . appSecret
+
+
+-- | Graph API version.
+-- See: https://developers.facebook.com/docs/graph-api/changelog
+type ApiVersion = Text
 
 -- | An access token.  While you can make some API calls without
 -- an access token, many require an access token and some will

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-03-15
+resolver: lts-13.21
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.21
+resolver: nightly-2018-03-15
 
 packages:
 - '.'

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -453,6 +453,18 @@ libraryTests manager = do
                    FB.parseSignedRequest
                      (B.concat [corruptedSig, ".", exampleData])
                  ret &?= (Nothing :: Maybe A.Value)
+
+  describe "addAppSecretProof" $
+    do it "appends appsecret_proof to the query when passing an access token" $
+         let token  = FB.UserAccessToken "id" "token" undefined
+             secret = "secret"
+             query  = [("test","whatever")]
+             secretProofQ creds = FB.makeAppSecretProof creds ( Just token )
+         in
+           do
+             creds <- getCredentials
+             FB.addAppSecretProof creds ( Just token ) query @?= secretProofQ creds <> query
+
   describe "FQLTime" $
     do it "seems to work" $
          do let input = "[1348678357]"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -456,13 +456,14 @@ libraryTests manager = do
 
   describe "addAppSecretProof" $
     do it "appends appsecret_proof to the query when passing an access token" $
-         let token  = FB.UserAccessToken "id" "token" undefined
-             query  = [("test","whatever")]
-             secretProofQ creds = FB.makeAppSecretProof creds ( Just token )
-         in
-           do
-             creds <- getCredentials
-             FB.addAppSecretProof creds ( Just token ) query @?= secretProofQ creds <> query
+         do
+            now <- liftIO TI.getCurrentTime
+            let token = FB.UserAccessToken "id" "token" now
+                query = [("test","whatever")]
+                secretProofQ creds = FB.makeAppSecretProof creds ( Just token )
+
+            creds <- getCredentials
+            FB.addAppSecretProof creds ( Just token ) query @?= secretProofQ creds <> query
 
   describe "FQLTime" $
     do it "seems to work" $

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -50,7 +50,7 @@ getCredentials = tryToGet `E.catch` showHelp
     tryToGet = do
       [appName, appId, appSecret] <-
         mapM getEnv ["APP_NAME", "APP_ID", "APP_SECRET"]
-      return $ FB.Credentials (T.pack appName) (T.pack appId) (T.pack appSecret)
+      return $ FB.Credentials (T.pack appName) (T.pack appId) (T.pack appSecret) True
     showHelp exc
       | not (isDoesNotExistError exc) = E.throwIO exc
     showHelp _ = do
@@ -78,7 +78,7 @@ getCredentials = tryToGet `E.catch` showHelp
       exitFailure
 
 invalidCredentials :: FB.Credentials
-invalidCredentials = FB.Credentials "this" "isn't" "valid"
+invalidCredentials = FB.Credentials "this" "isn't" "valid" False
 
 invalidUserAccessToken :: FB.UserAccessToken
 invalidUserAccessToken = FB.UserAccessToken (FB.Id "invalid") "user" farInTheFuture
@@ -318,7 +318,7 @@ facebookTests pretitle creds manager runAuth runNoAuth = do
                  -- Check user attributes
                  FB.userId createdUser &?= FB.tuId newTestUser
                  FB.userName createdUser &?= Just "Gabriel"
-                 -- FB.userLocale createdUser &?= Just "en_US"   -- fix this test later
+                 FB.userLocale createdUser &?= Just "en_US"   -- fix this test later
                  -- Check if the token is valid
                  FB.isValid newTestUserToken #?= False
                  removed &?= True
@@ -432,7 +432,7 @@ libraryTests manager = do
            exampleSig = "vlXgu64BQGFSQrY0ZcJBZASMvYvTHu9GQ0YM9rjPSso"
            exampleData =
              "eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsIjAiOiJwYXlsb2FkIn0"
-           exampleCreds = FB.Credentials "name" "id" "secret"
+           exampleCreds = FB.Credentials "name" "id" "secret" False
            runExampleAuth :: FB.FacebookT FB.Auth (R.ResourceT IO) a -> IO a
            runExampleAuth = R.runResourceT . FB.runFacebookT exampleCreds apiVersion manager
        it "works for Facebook example" $
@@ -457,7 +457,6 @@ libraryTests manager = do
   describe "addAppSecretProof" $
     do it "appends appsecret_proof to the query when passing an access token" $
          let token  = FB.UserAccessToken "id" "token" undefined
-             secret = "secret"
              query  = [("test","whatever")]
              secretProofQ creds = FB.makeAppSecretProof creds ( Just token )
          in


### PR DESCRIPTION
I've added a new parameter to `fbreq` (API version) and propagated it.