### PR TITLE
[#13] Add Support For Aeson v2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# master
+# Version 2.1.1.1
 
 * Add support for Aeson v2+.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* Add support for Aeson v2+.
+
 # Version 2.1.0
 
 * Same release as 2.0.1 bound follows PVP properly

--- a/fb.cabal
+++ b/fb.cabal
@@ -1,13 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: fbc728728a747ce7668aa69d724cc5c3bba4c229c78cace64848a9542775f837
 
 name:           fb
-version:        2.1.1
+version:        2.1.1.1
 synopsis:       Bindings to Facebook's API.
 description:    This package exports bindings to Facebook's APIs (see
                 <http://developers.facebook.com/>).  Does not have any external
@@ -73,7 +71,7 @@ library
   build-depends:
       aeson >=0.8.0.2
     , attoparsec >=0.10.4
-    , base >=4 && <5
+    , base ==4.*
     , bytestring >=0.9
     , conduit >=1.3.0
     , conduit-extra

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fb
-version: '2.1.1'
+version: '2.1.1.1'
 synopsis: Bindings to Facebook's API.
 description: ! 'This package exports bindings to Facebook''s APIs (see
 

--- a/src/Facebook/FQL.hs
+++ b/src/Facebook/FQL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -16,7 +17,12 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 
 import qualified Control.Monad.Trans.Resource as R
 import qualified Data.Aeson as A
-import qualified Data.HashMap.Strict as HMS
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as Keys
+#else
+import qualified Data.HashMap.Strict as Keys
+#endif
+
 
 import Facebook.Types
 import Facebook.Monad
@@ -66,7 +72,7 @@ newtype FQLList a = FQLList
 
 instance A.FromJSON a =>
          A.FromJSON (FQLList a) where
-  parseJSON (A.Object o) = FQLList <$> mapM A.parseJSON (HMS.elems o)
+  parseJSON (A.Object o) = FQLList <$> mapM A.parseJSON (Keys.elems o)
   parseJSON v = FQLList <$> A.parseJSON v
 
 -- | @newtype@ wrapper around any object that works around FQL's


### PR DESCRIPTION
Use CPP conditionals in the `Facebook.FQL` module to support Aeson v2 &
higher. The breaking release of aeson now uses a custom `KeyMap` type
instead of a `HashMap` for representing JSON objects.

If we can have a new release after this is merged, we can bring `fb` back into Stackage nightly.

Fixes #13